### PR TITLE
Update ggplot-heatmap.R so that column names follow the dendrogram/heatmap

### DIFF
--- a/R/ggplot-heatmap.R
+++ b/R/ggplot-heatmap.R
@@ -107,18 +107,20 @@ row.hc <- hclust(dist(x), "ward")
 col.hc <- hclust(dist(t(x)), "ward")
 row.dendro <- dendro_data(as.dendrogram(row.hc),type="rectangle")
 col.dendro <- dendro_data(as.dendrogram(col.hc),type="rectangle")
+
+## order of the dendros (part 1 of 2)
+col.ord <- match(col.dendro$labels$label, colnames(x))
+row.ord <- match(row.dendro$labels$label, rownames(x))
+xx <- x[row.ord,col.ord]
  
 ## dendro plots
 col.plot <- mydplot(col.dendro, col=TRUE, labels=TRUE) +
-scale_x_continuous(breaks = 1:ncol(x),labels=colnames(x)) +
+scale_x_continuous(breaks = 1:ncol(x),labels=colnames(xx)) +
 theme(plot.margin = unit(c(0,0,0,0), "lines"))
 row.plot <- mydplot(row.dendro, row=TRUE, labels=FALSE) +
 theme(plot.margin = unit(rep(0, 4), "lines"))
  
-## order of the dendros
-col.ord <- match(col.dendro$labels$label, colnames(x))
-row.ord <- match(row.dendro$labels$label, rownames(x))
-xx <- x[row.ord,col.ord]
+## order of the dendros (part 2 of 2)
 dimnames(xx) <- NULL
 xx <- melt(xx)
  


### PR DESCRIPTION
Previously, the column names (leaves on the dendrogram) were not plotted with their respective branches created by hierarchical clustering. Instead, they were displayed in their original input order.

I changed labels=colnames(x) to labels=colnames(xx) in col.plot in ggheatmap function and the order of "##order of dendros" wrt "##dendro plots".

![ggheatmap_ex](https://f.cloud.github.com/assets/5115662/1676539/3eaa15ea-5d1b-11e3-8280-8299a15cc2a4.png)

Thank you for sharing this script, it was very helpful!
